### PR TITLE
Change error handling logic

### DIFF
--- a/cmd/emblemcheck/main.go
+++ b/cmd/emblemcheck/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"bufio"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -34,8 +35,11 @@ var tokenGroup = 5
 var tokenReg *regexp.Regexp = regexp.MustCompile(`^adem-((emb|end)-\d+)(-p(\d+))?=(.+)`)
 
 func loadTokensDNS() ([][]byte, error) {
+    if _, err := net.LookupIP(args.AssetDomainName); err != nil {
+        return nil, err
+    }
 	if records, err := net.LookupTXT(args.AssetDomainName); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("no TXT record for %s found", args.AssetDomainName)
 	} else {
 		tokens := map[string][]string{}
 		for _, record := range records {


### PR DESCRIPTION
Connected to https://github.com/adem-wg/adem-proto/issues/3

1. If a DNS query for an A record (host address) fails to resolve, return a "no such host" error message. Note that future ADEM functionality may not always require an associated IP address, potentially rendering this check restrictive.
2. If a DNS query for a TXT record fails to resolve, return a "no TXT record found" error message. This check is a critical requirement. Adds more logic and overview where the actual problem is. 